### PR TITLE
fix: Align README instructions with dev.vars.example

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,2 +1,9 @@
-JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
-COOKIE_ENCRYPTION_KEY=12345678901234567890123456789012
+# Database Configuration
+DATABASE_URL="postgresql://username:password@host:port/database"
+
+# Security Keys (IMPORTANT: Generate strong, unique keys)
+JWT_SECRET="your-super-secret-jwt-key-at-least-32-characters-long"
+COOKIE_ENCRYPTION_KEY="exactly-32-characters-for-encryption"
+
+# Optional: Image Generation (if using Workers AI)
+# ALLOWED_IMAGE_USERS="username1,username2"

--- a/README.md
+++ b/README.md
@@ -261,19 +261,7 @@ cp .dev.vars.example .dev.vars
 nano .dev.vars
 ```
 
-Add your configuration:
-
-```ini
-# Database Configuration
-DATABASE_URL="postgresql://username:password@host:port/database"
-
-# Security Keys (IMPORTANT: Generate strong, unique keys)
-JWT_SECRET="your-super-secret-jwt-key-at-least-32-characters-long"
-COOKIE_ENCRYPTION_KEY="exactly-32-characters-for-encryption"
-
-# Optional: Image Generation (if using Workers AI)
-# ALLOWED_IMAGE_USERS="username1,username2"
-```
+Configure the values to match your environment in .dev.vars.
 
 **🔒 Security Note**: Generate strong secrets:
 ```bash


### PR DESCRIPTION
GitHub: close: GH-8

The setup instructions in the README were duplicated contents with the contents of `dev.vars.example`. This could lead users to create duplicate entries for `JWT_SECRET` and `COOKIE_ENCRYPTION_KEY` in their `dev.vars` file.

This commit resolves this duplicated contents by:
1. Updating `dev.vars.example` to serve as a complete template, including all necessary variables.
2. Simplifying the README instructions to direct users to copy and modify the example file, creating a single source of truth for setup.